### PR TITLE
Trigger a github release as soon as changes are merged to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: "release"
+
+on:
+  push:
+    branches:
+      - "release"
+
+jobs:
+  pre-release:
+    name: "Release"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "latest"
+          prerelease: false
+          title: "Release Build"


### PR DESCRIPTION
We automiatically deploy to production when we merge changes to the release branch. We want those changes to get matched with a github release. This action creates a github release with changelog since last release.