### PR TITLE
Add a SEO to +layout.svelte

### DIFF
--- a/packages/web/src/routes/+layout.svelte
+++ b/packages/web/src/routes/+layout.svelte
@@ -1,5 +1,12 @@
 <script>
   import "../app.css";
+  import { page } from "$app/stores";
 </script>
 
 <slot />
+
+<svelte:head>
+  <!-- Simple SEO for now requires a title and description to be provided by the child route -->
+  <title>{$page.data.title}</title>
+  <meta name="description" content={$page.data.description} />
+</svelte:head>

--- a/packages/web/src/routes/+page.ts
+++ b/packages/web/src/routes/+page.ts
@@ -1,0 +1,6 @@
+export async function load() {
+  return {
+    title: "Cura Rehab",
+    description: "A website for Cura Rehab"
+  };
+}

--- a/packages/web/src/routes/sitemap.xml/+server.ts
+++ b/packages/web/src/routes/sitemap.xml/+server.ts
@@ -1,0 +1,25 @@
+export async function GET() {
+  return new Response(
+    `
+    <?xml version="1.0" encoding="UTF-8" ?>
+    <urlset
+      xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"
+      xmlns:xhtml="https://www.w3.org/1999/xhtml"
+      xmlns:mobile="https://www.google.com/schemas/sitemap-mobile/1.0"
+      xmlns:news="https://www.google.com/schemas/sitemap-news/0.9"
+      xmlns:image="https://www.google.com/schemas/sitemap-image/1.1"
+      xmlns:video="https://www.google.com/schemas/sitemap-video/1.1"
+    >
+      <url>
+        <loc>https://curarehab.se/</loc>
+        <changefreq>daily</changefreq>
+        <priority>1.0</priority>
+      </url>
+    </urlset>`.trim(),
+    {
+      headers: {
+        "Content-Type": "application/xml"
+      }
+    }
+  );
+}


### PR DESCRIPTION
We follow the official guide and add SEO to the root +layout.svelte. The headers are populated from child route data passed from load.
* [Official guide](https://kit.svelte.dev/docs/seo)
* [Pass data on load](https://kit.svelte.dev/docs/load)

For more advanced SEO that will make our website look better when pasted into SLACK, Twitter, etc we can draw inspiration from here:
* [SEO guide](https://rodneylab.com/sveltekit-seo/)
* [SEO component](https://github.com/rodneylab/sveltekit-blog-mdx/blob/main/src/lib/components/SEO/index.svelte)