### PR TITLE
Fix issues with SEO and localisation

### DIFF
--- a/packages/web/src/lib/i18n/en/index.ts
+++ b/packages/web/src/lib/i18n/en/index.ts
@@ -1,16 +1,16 @@
-import type { AboutTranslations, CommonTranslations, HomeTranslations } from "../types";
+import type { OmTranslations, CommonTranslations, HemTranslations } from "../types";
 
 export const common: CommonTranslations = {
   link: "/en{{link}}"
 };
 
-export const home: HomeTranslations = {
+export const hem: HemTranslations = {
   title: "Cura Rehab",
   description: "A website for Cura Rehab",
   aboutLink: "Read about us"
 };
 
-export const about: AboutTranslations = {
+export const om: OmTranslations = {
   title: "About",
   description: "About Cura Rehab"
 };

--- a/packages/web/src/lib/i18n/index.ts
+++ b/packages/web/src/lib/i18n/index.ts
@@ -1,17 +1,15 @@
-import { browser } from "$app/environment";
 import type { Config } from "sveltekit-i18n";
 import i18n from "sveltekit-i18n";
 import type { Categories, Locale } from "./types";
 
 export const locales: Locale[] = ["en", "sv"];
-const localeSet = new Set(locales);
 export const defaultLocale: Locale = "sv";
 
 const config = ((): Config => {
   const categories: ({ category: Categories } & { route?: string })[] = [
     { category: "common" },
-    { category: "home", route: "/" },
-    { category: "about", route: "/about" }
+    { category: "hem", route: "/" },
+    { category: "om", route: "/om" }
   ];
 
   // Create a loader for each locale and category
@@ -32,13 +30,3 @@ const config = ((): Config => {
 })();
 
 export const { t, locale, loading, loadTranslations } = new i18n(config);
-
-export const detectLocale = (): Locale => {
-  if (!browser) return defaultLocale;
-  const locale = navigator.language;
-  const detectedLocales = [window.location.pathname.split("/")[1], locale, locale.split("-")[0]];
-  for (const detectedLocale of detectedLocales) {
-    if (localeSet.has(detectedLocale as Locale)) return detectedLocale as Locale;
-  }
-  return defaultLocale;
-};

--- a/packages/web/src/lib/i18n/sv/index.ts
+++ b/packages/web/src/lib/i18n/sv/index.ts
@@ -1,16 +1,16 @@
-import type { AboutTranslations, CommonTranslations, HomeTranslations } from "../types";
+import type { OmTranslations, CommonTranslations, HemTranslations } from "../types";
 
 export const common: CommonTranslations = {
-  link: "/sv{{link}}"
+  link: "{{link}}"
 };
 
-export const home: HomeTranslations = {
+export const hem: HemTranslations = {
   title: "Cura Rehab",
   description: "En hemsida för Cura Rehab",
   aboutLink: "Läs om oss"
 };
 
-export const about: AboutTranslations = {
+export const om: OmTranslations = {
   title: "Om",
   description: "Om Cura Rehab"
 };

--- a/packages/web/src/lib/i18n/types.ts
+++ b/packages/web/src/lib/i18n/types.ts
@@ -1,17 +1,17 @@
 export type Locale = "en" | "sv";
-export type Categories = "common" | "about" | "home";
+export type Categories = "common" | "om" | "hem";
 
 export type CommonTranslations = {
   link: string;
 };
 
-export type HomeTranslations = {
+export type HemTranslations = {
   title: string;
   description: string;
   aboutLink: string;
 };
 
-export type AboutTranslations = {
+export type OmTranslations = {
   title: string;
   description: string;
 };

--- a/packages/web/src/routes/+layout.ts
+++ b/packages/web/src/routes/+layout.ts
@@ -1,17 +1,23 @@
-import { detectLocale, loadTranslations, locales } from "$lib/i18n";
+import { defaultLocale, loadTranslations, locales } from "$lib/i18n";
 import type { Locale } from "$lib/i18n/types";
+import { error, redirect } from "@sveltejs/kit";
 import type { LayoutLoad } from "./$types";
 
 export const load: LayoutLoad = async (event) => {
   const { pathname } = event.url;
   const { lang } = event.params;
 
-  const locale: Locale = locales.find((l) => l === lang) || detectLocale();
+  const localeExists = locales.find((l) => l === lang);
+  if (lang && !localeExists) throw error(404, "Not found");
+
+  const locale: Locale = localeExists || defaultLocale;
   const route = ((): string => {
     if (!lang) return pathname;
     else if (pathname === `/${lang}`) return "/";
     else return pathname.replace(`/${lang}`, "");
   })();
+
+  if (localeExists === defaultLocale) throw redirect(308, route);
 
   await loadTranslations(locale, route);
 

--- a/packages/web/src/routes/[[lang]]/+page.svelte
+++ b/packages/web/src/routes/[[lang]]/+page.svelte
@@ -3,14 +3,14 @@
 </script>
 
 <div class="p-4">
-  <h1>{$t("home.title")}</h1>
-  <p>{$t("home.description")}</p>
-  <a href={$t("common.link", { default: "/about" })}>{$t("home.aboutLink")}</a>
+  <h1>{$t("hem.title")}</h1>
+  <p>{$t("hem.description")}</p>
+  <a href={$t("common.link", { default: "/om" })}>{$t("hem.aboutLink")}</a>
 </div>
 
 <!-- TODO: Make this a component -->
 <svelte:head>
   <!-- Simple SEO for now requires a title and description to be provided by the child route -->
-  <title>{$t("home.title")}</title>
-  <meta name="description" content={$t("home.description")} />
+  <title>{$t("hem.title")}</title>
+  <meta name="description" content={$t("hem.description")} />
 </svelte:head>

--- a/packages/web/src/routes/[[lang]]/om/+page.svelte
+++ b/packages/web/src/routes/[[lang]]/om/+page.svelte
@@ -3,12 +3,12 @@
 </script>
 
 <div class="p-4">
-  <h1>{$t("about.title")}</h1>
-  <p>{$t("about.description")}</p>
+  <h1>{$t("om.title")}</h1>
+  <p>{$t("om.description")}</p>
 </div>
 
 <svelte:head>
   <!-- Simple SEO for now requires a title and description to be provided by the child route -->
-  <title>{$t("about.title")}</title>
-  <meta name="description" content={$t("about.description")} />
+  <title>{$t("om.title")}</title>
+  <meta name="description" content={$t("om.description")} />
 </svelte:head>

--- a/packages/web/src/routes/sitemap.xml/+server.ts
+++ b/packages/web/src/routes/sitemap.xml/+server.ts
@@ -1,14 +1,15 @@
-import { locales } from "$lib/i18n";
+import { defaultLocale, locales } from "$lib/i18n";
 
-const urls = [...locales.map((l) => `/${l}`), ""].flatMap((locale) =>
-  ["", "/about"].map((route) => {
-    return `
+const urls = [...locales.filter((l) => l !== defaultLocale).map((l) => `/${l}`), ""].flatMap(
+  (locale) =>
+    ["", "/om"].map((route) => {
+      return `
       <url>
         <loc>https://curarehab.se${locale}${route}</loc>
         <changefreq>daily</changefreq>
         <priority>1.0</priority>
       </url>`.trim();
-  })
+    })
 );
 
 export async function GET() {

--- a/packages/web/tests/i18n.test.ts
+++ b/packages/web/tests/i18n.test.ts
@@ -1,21 +1,29 @@
 import { expect, test } from "@playwright/test";
-import { home as svHome, about as svAbout } from "$lib/i18n/sv/index";
-import { home as enHome, about as enAbout } from "$lib/i18n/en/index";
+import { hem as svHem, om as svOm } from "$lib/i18n/sv/index";
+import { hem as enHem, om as enOm } from "$lib/i18n/en/index";
 
-test.describe("Check that pages are localized and have SEO headers", () => {
-  for (const {
-    route,
-    data: { title, description }
-  } of [
-    { route: "/", data: enHome },
-    { route: "/sv", data: svHome },
-    { route: "/en", data: enHome },
-    { route: "/about", data: enAbout },
-    { route: "/sv/about", data: svAbout },
-    { route: "/en/about", data: enAbout }
+test.describe("Test locale, SEO, status and redirects", () => {
+  for (const { route, expectedRoute, data, status } of [
+    { route: "/", data: svHem, status: 200 },
+    { route: "/sv", expectedRoute: "/", data: svHem, status: 200 },
+    { route: "/en", data: enHem, status: 200 },
+    { route: "/om", data: svOm, status: 200 },
+    { route: "/sv/om", expectedRoute: "/om", data: svOm, status: 200 },
+    { route: "/en/om", data: enOm, status: 200 },
+    { route: "/no", status: 404 },
+    { route: "/sitemap.xml", status: 200 },
+    { route: "/robots.txt", status: 404 }
   ]) {
-    test(`${route}`, async ({ page }) => {
-      await page.goto(route);
+    test(`${status}, ${route}`, async ({ page }) => {
+      const response = await page.goto(route);
+      if (!response) throw new Error("No response");
+
+      // Check that pages get redirected properly
+      expect(response.status()).toBe(status);
+      expect(response.url().endsWith(expectedRoute || route)).toBe(true);
+
+      if (!data) return;
+      const { title, description } = data;
       await expect(page.getByRole("heading", { name: title })).toBeVisible();
       expect(await page.title()).toBe(title);
       await expect(page.locator('meta[name="description"]')).toHaveAttribute(


### PR DESCRIPTION
We use a optional routing argument for locales which resulted in random pages on depth 1 all ending up in the '/' route. This resulted in robots.txt yielding a result which it should not have. In turn that dropped our SEO ranking.

We also dynamically changanged language due to browser defaults, this is not the recommended way to do it since. It is better to have different routes for different languages according to googles SEO guied. Thus we removed the '/sv/*' route and made the none localized route swedish.

We also added tests to validate that the behaviour is as expected, we redirected any route from '/sv/*' -> '/*'.

Our URL structure was english, since the site will primarily be used in Sweden we change the structure to be swedish, it will allow breadcrumbs to look better in search engines.

closes #18, #16, #14