### PR TITLE
Fix issue where cookies would be cleared to soon

### DIFF
--- a/packages/web/src/lib/cookies/index.ts
+++ b/packages/web/src/lib/cookies/index.ts
@@ -57,7 +57,7 @@ function getCookiePermissions(): CookieSettings {
       if (
         !lastUpdated ||
         (settings.permission && lastUpdated < twelveMonthsAgo) ||
-        lastUpdated < threeDaysAgo
+        (!settings.permission && lastUpdated < threeDaysAgo)
       ) {
         localStorage.removeItem("cookiePermission");
         clearCookies();


### PR DESCRIPTION
When permission for cookies was given the timeout of 3 days used for when permission was not given was used. This resulted in cookie dialog being reasked every 3 days, instead of once a year.